### PR TITLE
Fixes Bucklescript v7 warnings

### DIFF
--- a/src/ReactShallowRenderer.re
+++ b/src/ReactShallowRenderer.re
@@ -1,15 +1,15 @@
 type t;
 
 [@bs.module "react-test-renderer/shallow"] [@bs.val] external createRenderer :
-  unit => t = "";
+  unit => t = "createRenderer";
 
 [@bs.send] external render :
-  t => ReasonReact.reactElement => option(ReasonReact.reactElement) = "";
+  t => ReasonReact.reactElement => option(ReasonReact.reactElement) = "render";
 
 [@bs.send] external getRenderOutput :
-  t => option(ReasonReact.reactElement) = "";
+  t => option(ReasonReact.reactElement) = "getRenderOutput";
 
 [@bs.send] external unmount :
-  t => unit = "";
+  t => unit = "unmount";
 
 let renderWithRenderer = render(createRenderer());

--- a/src/ReactTestRenderer.re
+++ b/src/ReactTestRenderer.re
@@ -1,7 +1,7 @@
 type t;
 
 [@bs.module "react-test-renderer"] [@bs.val] external create :
-  ReasonReact.reactElement => t = "";
+  ReasonReact.reactElement => t = "create";
 
 [@bs.send] external toJSON :
-  t => Js.Json.t = "";
+  t => Js.Json.t = "toJSON";


### PR DESCRIPTION
Fixes:
BuckleScript warning: [name] : the external name is inferred from val name is unsafe from refactoring when changing value name

Please accept.